### PR TITLE
Simplify list tags flow

### DIFF
--- a/internal/github/api.go
+++ b/internal/github/api.go
@@ -7,12 +7,14 @@ import (
 	"net/http"
 )
 
-// FetchReferencesMatching fetches all references matching the passed in string for a specific
-// GitHub slug
-func FetchReferencesMatching(gitHubSlug string, matching string) ([]Reference, error) {
+// GitHubAPIV3BaseURL Base URL for the GitHub API V3
+const GitHubAPIV3BaseURL = "https://api.github.com"
+
+// FetchTags fetches all tags from a GitHub slug
+func FetchTags(gitHubSlug string) ([]Reference, error) {
 	allReferences := make([]Reference, 0)
 
-	url := fmt.Sprintf("%s/repos/%s/git/matching-refs/%s", GitHubAPIV3BaseURL, gitHubSlug, matching)
+	url := fmt.Sprintf("%s/repos/%s/git/refs/tags", GitHubAPIV3BaseURL, gitHubSlug)
 	request, requestErr := http.NewRequest(http.MethodGet, url, nil)
 	if requestErr != nil {
 		return allReferences, requestErr
@@ -46,9 +48,4 @@ func FetchReferencesMatching(gitHubSlug string, matching string) ([]Reference, e
 	allReferences = append(allReferences, references...)
 
 	return allReferences, nil
-}
-
-// FetchTags fetches all tags from a GitHub slug
-func FetchTags(gitHubSlug string) ([]Reference, error) {
-	return FetchReferencesMatching(gitHubSlug, "tags")
 }

--- a/internal/github/commands.go
+++ b/internal/github/commands.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/spf13/cobra"
 )
@@ -31,7 +32,7 @@ func createListTagsCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			tags, err := FetchTags(args[0])
 			if err != nil {
-				panic(err)
+				log.Fatal(err)
 			}
 
 			fmt.Printf("%d tags found:\n", len(tags))

--- a/internal/github/constants.go
+++ b/internal/github/constants.go
@@ -1,9 +1,0 @@
-package github
-
-const (
-	// GitHubAPIV3BaseURL Base URL for the GitHub API V3
-	GitHubAPIV3BaseURL = "https://api.github.com"
-
-	// ReferenceTagPrefix References that have this prefix are tags
-	ReferenceTagPrefix = "refs/tags/"
-)

--- a/internal/github/errors.go
+++ b/internal/github/errors.go
@@ -13,7 +13,7 @@ func generateErrorFrom(url string, response *http.Response) error {
 
 	bodyData, _ := ioutil.ReadAll(response.Body)
 	if len(bodyData) >= 0 {
-		errorMessage = fmt.Sprintf("%s\nBody:\n%s\n", errorMessage, string(bodyData))
+		errorMessage = fmt.Sprintf("%s\n-- Body --\n%s\n----------\n", errorMessage, string(bodyData))
 	}
 
 	return errors.New(errorMessage)

--- a/internal/github/references.go
+++ b/internal/github/references.go
@@ -2,6 +2,9 @@ package github
 
 import "strings"
 
+// ReferenceTagPrefix References that have this prefix are tags
+const ReferenceTagPrefix = "refs/tags/"
+
 // Reference represents a reference to an object in the GitHub Git Database
 // https://developer.github.com/v3/git/
 type Reference struct {


### PR DESCRIPTION
Refactor some code, use the `/refs` endpoint to fetch all tags instead of the `matching` endpoint.