### PR TITLE
Add parse semantic version command

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+# What's in this PR?
+
+<!-- Brief description of the change in this PR. -->
+
+# How did I test it?
+
+<!-- Describe all the things you did to test it. -->
+
+# To Do
+
+<!--
+  If all work is already in pushed, remove this section.
+  Otherwise, add a list with checkboxes like:
+-->
+
+- [ ] Add Unit tests
+- [ ] Document external functions

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/VinnieApps/cicd-tools/internal/github"
+	"github.com/VinnieApps/cicd-tools/internal/semver"
 	"github.com/spf13/cobra"
 )
 
@@ -13,5 +14,6 @@ func main() {
 	}
 
 	rootCommand.AddCommand(github.CreateGitHubCommand())
+	rootCommand.AddCommand(semver.CreateSemVerCommand())
 	rootCommand.Execute()
 }

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmg
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/internal/semver/commands.go
+++ b/internal/semver/commands.go
@@ -1,0 +1,36 @@
+package semver
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+// CreateSemVerCommand creates the root Semantic Version command
+func CreateSemVerCommand() *cobra.Command {
+	semVerCommand := &cobra.Command{
+		Use:   "semver",
+		Short: "All commands related to Semantic Versioning",
+		Long:  "To learn more about Semantic Versioning: https://semver.org/",
+	}
+
+	semVerCommand.AddCommand(createParseSemVerCommand())
+	return semVerCommand
+}
+
+func createParseSemVerCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:  "parse {SEMVER_STRING}",
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			version, err := Parse(args[0])
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			fmt.Printf("Major: %d, Minor: %d, Patch: %d\n", version.Major, version.Minor, version.Patch)
+		},
+	}
+}

--- a/internal/semver/parse.go
+++ b/internal/semver/parse.go
@@ -1,0 +1,32 @@
+package semver
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+var semVerFormat = regexp.MustCompile("v?(\\d+)\\.(\\d+)\\.(\\d+)")
+
+// SemVer represents a semantic version
+type SemVer struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+// Parse parses a string to a SemVer
+func Parse(toParse string) (SemVer, error) {
+	version := SemVer{}
+
+	if !semVerFormat.MatchString(toParse) {
+		return version, fmt.Errorf("Invalid SemVer format: %s", toParse)
+	}
+
+	parts := semVerFormat.FindStringSubmatch(toParse)
+	version.Major, _ = strconv.Atoi(parts[1])
+	version.Minor, _ = strconv.Atoi(parts[2])
+	version.Patch, _ = strconv.Atoi(parts[3])
+
+	return version, nil
+}

--- a/internal/semver/parse_test.go
+++ b/internal/semver/parse_test.go
@@ -1,0 +1,36 @@
+package semver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	validVersions := []string{
+		"0.0.0",
+		"0.2.13",
+		"1.0.0",
+		"431.123.9421",
+	}
+
+	expectedVersions := [][]int{
+		[]int{0, 0, 0},
+		[]int{0, 2, 13},
+		[]int{1, 0, 0},
+		[]int{431, 123, 9421},
+	}
+
+	for _, prefix := range []string{"", "v"} {
+		for index, validVersion := range validVersions {
+			version, err := Parse(prefix + validVersion)
+			require.Nil(t, err, "Should parse "+validVersion+" correctly")
+
+			expectedVersion := expectedVersions[index]
+			assert.Equal(t, version.Major, expectedVersion[0])
+			assert.Equal(t, version.Minor, expectedVersion[1])
+			assert.Equal(t, version.Patch, expectedVersion[2])
+		}
+	}
+}


### PR DESCRIPTION
# What's in this PR?

- Add infrastructure to parse semantic version string to a struct
- Add a command that can parse and print semantic versions
- Add a template for Pull Requests

# How did I test it?

- Added unit tests for the parse function
- Tested the parse command manually:

```
$ go run cmd/main.go semver parse 10
2020/03/14 21:37:26 Invalid SemVer format: 10
exit status 1

 $ go run cmd/main.go semver parse 10.123.321
Major: 10, Minor: 123, Patch: 321

$ go run cmd/main.go semver parse 0.0.0
Major: 0, Minor: 0, Patch: 0

$ go run cmd/main.go semver parse v0.3.1
Major: 0, Minor: 3, Patch: 1
```
