### PR TITLE
Add golang, list-packages and run-tests commands

### DIFF
--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -22,4 +22,4 @@ jobs:
         run: go build -v cmd/main.go
 
       - name: Test
-        run: go test -v ./...
+        run: go run cmd/main.go golang run-tests

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -23,3 +23,6 @@ jobs:
 
       - name: Test
         run: go run cmd/main.go golang run-tests
+      
+      - name: Show Coverage
+        run: go tool cover -func=build/coverage/all.out

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+build/
 .DS_Store
 .version

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/VinnieApps/cicd-tools/internal/github"
+	"github.com/VinnieApps/cicd-tools/internal/golang"
 	"github.com/VinnieApps/cicd-tools/internal/semrel"
 	"github.com/VinnieApps/cicd-tools/internal/semver"
 	"github.com/spf13/cobra"
@@ -15,6 +16,7 @@ func main() {
 	}
 
 	rootCommand.AddCommand(github.CreateGitHubCommand())
+	rootCommand.AddCommand(golang.CreateGoCommand())
 	rootCommand.AddCommand(semrel.CreateSemanticReleaseCommand())
 	rootCommand.AddCommand(semver.CreateSemVerCommand())
 	rootCommand.Execute()

--- a/internal/golang/commands.go
+++ b/internal/golang/commands.go
@@ -1,0 +1,52 @@
+package golang
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+// CreateGoCommand creates the root Go command
+func CreateGoCommand() *cobra.Command {
+	goCommand := &cobra.Command{
+		Use:   "golang",
+		Short: "All commands related to the language Go",
+	}
+
+	goCommand.AddCommand(createListPackagesCommand())
+	goCommand.AddCommand(createRunTestsCommand())
+	return goCommand
+}
+
+func createListPackagesCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list-packages",
+		Short: "List packages in a directory",
+		Run: func(cmd *cobra.Command, args []string) {
+			packages, readErr := ListPackages(".")
+			if readErr != nil {
+				log.Fatal(readErr)
+			}
+
+			for _, pkg := range packages {
+				fmt.Printf("%s: %s -> %s\n", pkg.Name, pkg.Dir, pkg.ImportPath)
+			}
+		},
+	}
+}
+
+func createRunTestsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "run-tests",
+		Short: "Run all the tests and collect coverage",
+		Run: func(cmd *cobra.Command, args []string) {
+			packages, readErr := ListPackages(".")
+			if readErr != nil {
+				log.Fatal(readErr)
+			}
+
+			RunTestsWithCoverage(packages)
+		},
+	}
+}

--- a/internal/golang/packages.go
+++ b/internal/golang/packages.go
@@ -1,0 +1,28 @@
+package golang
+
+import (
+	"fmt"
+	"go/build"
+	"os"
+	"path/filepath"
+)
+
+// ListPackages lists all go packages in the specified path and subpath
+func ListPackages(path string) ([]*build.Package, error) {
+	packages := make([]*build.Package, 0)
+
+	walkErr := filepath.Walk(path, func(subPath string, info os.FileInfo, err error) error {
+		pkg, readErr := build.Import(fmt.Sprintf("./%s", subPath), ".", build.ImportComment)
+		if readErr == nil {
+			packages = append(packages, pkg)
+		}
+
+		return nil
+	})
+
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	return packages, nil
+}

--- a/internal/golang/tests.go
+++ b/internal/golang/tests.go
@@ -1,0 +1,54 @@
+package golang
+
+import (
+	"fmt"
+	"go/build"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// RunTestsWithCoverage runs tests for all packages and generate coverage data.
+// This method is guarantee to generate coverage counts even when the package has no
+// tests.
+func RunTestsWithCoverage(packages []*build.Package) error {
+	os.MkdirAll("build/coverage", 0744)
+	filesToCollect := make([]string, 0)
+	for i, pkg := range packages {
+		fmt.Printf("Running tests for %s\n", pkg.ImportPath)
+
+		tempCoverOuptutFile := fmt.Sprintf("build/coverage/temp_%d.out", i)
+		filesToCollect = append(filesToCollect, tempCoverOuptutFile)
+
+		packageTestFile := filepath.Join(pkg.Dir, fmt.Sprintf("%s_test.go", pkg.Name))
+		if _, err := os.Stat(packageTestFile); os.IsNotExist(err) {
+			ioutil.WriteFile(packageTestFile, []byte("package "+pkg.Name), 0644)
+			defer os.Remove(packageTestFile)
+		}
+
+		cmd := exec.Command("go", "test", "-cover", "-coverprofile="+tempCoverOuptutFile, pkg.ImportPath)
+		runErr := cmd.Run()
+		if runErr != nil {
+			log.Printf("Error running test for: %s\n", pkg.ImportPath)
+			output, _ := cmd.CombinedOutput()
+			log.Println(string(output))
+			log.Fatal(runErr)
+		}
+	}
+
+	allData := "mode: set\n"
+	for _, file := range filesToCollect {
+		data, readErr := ioutil.ReadFile(file)
+		if readErr != nil {
+			log.Fatal(readErr)
+		}
+
+		allData += strings.Join(strings.Split(string(data), "\n")[1:], "\n")
+	}
+	ioutil.WriteFile("build/coverage/collected.out", []byte(allData), 0644)
+
+	return nil
+}


### PR DESCRIPTION
# What's in this PR?

- Added a golang root command
- Added a list-packages for golang, not very useful, but it's there for testing purposes
- Added a run-tests for golang which will force the generation of coverage for all packages, including ones without any test file

# How did I test it?

- Run the list-packages command manually and verified that it prints the packages correctly
- Run the run-tests command manually and verified that it generates coverage for all packages
