### PR TITLE
Fix module name from cicd-tools to cicd-toolbox

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/VinnieApps/cicd-tools/internal/github"
-	"github.com/VinnieApps/cicd-tools/internal/golang"
-	"github.com/VinnieApps/cicd-tools/internal/semrel"
-	"github.com/VinnieApps/cicd-tools/internal/semver"
+	"github.com/VinnieApps/cicd-toolbox/internal/github"
+	"github.com/VinnieApps/cicd-toolbox/internal/golang"
+	"github.com/VinnieApps/cicd-toolbox/internal/semrel"
+	"github.com/VinnieApps/cicd-toolbox/internal/semver"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-module github.com/VinnieApps/cicd-tools
+module github.com/VinnieApps/cicd-toolbox
 
 go 1.13
 
 require (
-	github.com/go-git/go-git v4.7.0+incompatible
+	github.com/go-git/go-git v4.7.0+incompatible // indirect
 	github.com/go-git/go-git/v5 v5.0.0
 	github.com/spf13/cobra v0.0.6
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,10 @@ github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBb
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -27,9 +29,11 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
+github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
 github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
@@ -54,6 +58,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -91,6 +96,7 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/semrel/calculate_change.go
+++ b/internal/semrel/calculate_change.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/VinnieApps/cicd-tools/internal/git"
+	"github.com/VinnieApps/cicd-toolbox/internal/git"
 )
 
 var breakingChangePattern = regexp.MustCompile("BREAKING CHANGE?")

--- a/internal/semrel/calculate_change_test.go
+++ b/internal/semrel/calculate_change_test.go
@@ -3,7 +3,7 @@ package semrel
 import (
 	"testing"
 
-	"github.com/VinnieApps/cicd-tools/internal/git"
+	"github.com/VinnieApps/cicd-toolbox/internal/git"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/semrel/commands.go
+++ b/internal/semrel/commands.go
@@ -4,9 +4,9 @@ import (
 	"io/ioutil"
 	"log"
 
-	"github.com/VinnieApps/cicd-tools/internal/git"
-	"github.com/VinnieApps/cicd-tools/internal/github"
-	"github.com/VinnieApps/cicd-tools/internal/semver"
+	"github.com/VinnieApps/cicd-toolbox/internal/git"
+	"github.com/VinnieApps/cicd-toolbox/internal/github"
+	"github.com/VinnieApps/cicd-toolbox/internal/semver"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/semrel/release.go
+++ b/internal/semrel/release.go
@@ -1,8 +1,8 @@
 package semrel
 
 import (
-	"github.com/VinnieApps/cicd-tools/internal/git"
-	"github.com/VinnieApps/cicd-tools/internal/semver"
+	"github.com/VinnieApps/cicd-toolbox/internal/git"
+	"github.com/VinnieApps/cicd-toolbox/internal/semver"
 )
 
 // Release represents a group of changes that will be released

--- a/internal/semrel/release_test.go
+++ b/internal/semrel/release_test.go
@@ -3,8 +3,8 @@ package semrel
 import (
 	"testing"
 
-	"github.com/VinnieApps/cicd-tools/internal/git"
-	"github.com/VinnieApps/cicd-tools/internal/semver"
+	"github.com/VinnieApps/cicd-toolbox/internal/git"
+	"github.com/VinnieApps/cicd-toolbox/internal/semver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
# What's in this PR?

Fixing the module name from cicd-tools to cicd-toolbox.

# How did I test it?

Ran all the unit tests.
