### PR TITLE
Add Change log command

### DIFF
--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -22,7 +22,15 @@ jobs:
         run: go run cmd/main.go golang build --os darwin --os linux --os windows --arch amd64 cmd/main.go
 
       - name: Test
-        run: build/binaries/amd64_linux/main golang run-tests
+        run: go run cmd/main.go golang run-tests
       
       - name: Show Coverage
         run: go tool cover -func=build/coverage/all.out
+
+      - name: Calculate Next Version
+        run: |
+          go run cmd/main.go semantic-release version-file vinnieapps/cicd-toolbox
+          cat .version
+
+      - name: Change Log
+        run: go run cmd/main.go semantic-release change-log vinnieapps/cicd-toolbox

--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -17,7 +17,9 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v2
-      
+        with:
+          fetch-depth: 0
+
       - name: Build
         run: go run cmd/main.go golang build --os darwin --os linux --os windows --arch amd64 cmd/main.go
 

--- a/internal/git/commit.go
+++ b/internal/git/commit.go
@@ -5,3 +5,8 @@ type Commit struct {
 	Message string `json:"message"`
 	SHA     string `json:"sha"`
 }
+
+// ShortSHA returns the short version of the commit's SHA
+func (commit Commit) ShortSHA() string {
+	return commit.SHA[:8]
+}

--- a/internal/git/commit_test.go
+++ b/internal/git/commit_test.go
@@ -1,0 +1,16 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShortSHA(t *testing.T) {
+	commit := Commit{
+		Message: "Some Message",
+		SHA:     "92901dd395bc8854dab596d2a4cb3bc19757930e",
+	}
+
+	assert.Equal(t, "92901dd3", commit.ShortSHA())
+}

--- a/internal/golang/build.go
+++ b/internal/golang/build.go
@@ -22,8 +22,8 @@ type BuildSpecification struct {
 // Build builds the binaries using the build spec
 func (buildSpec *BuildSpecification) Build() []error {
 	parallel := runtime.NumCPU() - 1
-	if parallel <= 0 {
-		parallel = 1
+	if parallel < 0 {
+		parallel = 0
 	}
 
 	var errorLock sync.Mutex

--- a/internal/semrel/calculate_next_release.go
+++ b/internal/semrel/calculate_next_release.go
@@ -1,0 +1,47 @@
+package semrel
+
+import (
+	"github.com/VinnieApps/cicd-toolbox/internal/git"
+	"github.com/VinnieApps/cicd-toolbox/internal/semver"
+)
+
+// CalculateNextRelease will calculate what will go out in the next release,
+// and if it is a major, minor or patch change.
+func CalculateNextRelease(latestVersion semver.Version, commits []git.Commit) (Release, error) {
+	release := Release{}
+
+	release.Version = semver.Version{
+		Major: latestVersion.Major,
+		Minor: latestVersion.Minor,
+		Patch: latestVersion.Patch,
+	}
+
+	major := false
+	minor := false
+
+	release.Changes = make([]Change, len(commits))
+	for i, commit := range commits {
+		change := CalculateChange(commit)
+		major = major || change.Major
+		minor = minor || change.Minor
+
+		release.Changes[i] = change
+	}
+
+	if len(release.Changes) > 0 {
+		release.Version.Patch++
+	}
+
+	if minor {
+		release.Version.Minor++
+		release.Version.Patch = 0
+	}
+
+	if major {
+		release.Version.Major++
+		release.Version.Minor = 0
+		release.Version.Patch = 0
+	}
+
+	return release, nil
+}

--- a/internal/semrel/calculate_next_release_test.go
+++ b/internal/semrel/calculate_next_release_test.go
@@ -1,0 +1,86 @@
+package semrel
+
+import (
+	"testing"
+
+	"github.com/VinnieApps/cicd-toolbox/internal/git"
+	"github.com/VinnieApps/cicd-toolbox/internal/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateNextReleaseReturnsSameIfNoCommits(t *testing.T) {
+	release, err := CalculateNextRelease(semver.Version{}, make([]git.Commit, 0))
+
+	require.Nil(t, err)
+	assert.Equal(t, "0.0.0", release.Version.String())
+}
+
+func TestCalculateNextReleaseAlwaysReturnNextPatch(t *testing.T) {
+	commits := []git.Commit{
+		git.Commit{
+			Message: "chore: this is a test",
+			SHA:     "1234abcd1234",
+		},
+		git.Commit{
+			Message: "Merge PR Bla Bla Bla",
+			SHA:     "1234abcd1234",
+		},
+		git.Commit{
+			Message: "refactor: move code from here to there",
+			SHA:     "1234abcd1234",
+		},
+	}
+	release, err := CalculateNextRelease(semver.Version{}, commits)
+
+	require.Nil(t, err)
+	assert.Equal(t, "0.0.1", release.Version.String())
+}
+
+func TestCalculateNextReleaseReturnNextMinorIfNewFeature(t *testing.T) {
+	commits := []git.Commit{
+		git.Commit{
+			Message: "feature: this is a test",
+			SHA:     "1234abcd1234",
+		},
+		git.Commit{
+			Message: "Merge PR Bla Bla Bla",
+			SHA:     "1234abcd1234",
+		},
+		git.Commit{
+			Message: "feat: move code from here to there",
+			SHA:     "1234abcd1234",
+		},
+	}
+	release, err := CalculateNextRelease(semver.Version{}, commits)
+
+	require.Nil(t, err)
+	assert.Equal(t, "0.1.0", release.Version.String())
+}
+
+func TestCalculateNextReleaseReturnNextMajorWhenBreakingChange(t *testing.T) {
+	commits := []git.Commit{
+		git.Commit{
+			Message: `feat: this is a new feature
+
+This is an important change.
+
+BREAKING CHANGE:
+Now the return value is going to be encrypted.
+`,
+			SHA: "1234abcd1234",
+		},
+		git.Commit{
+			Message: "Merge PR Bla Bla Bla",
+			SHA:     "1234abcd1234",
+		},
+		git.Commit{
+			Message: "feat: move code from here to there",
+			SHA:     "1234abcd1234",
+		},
+	}
+	release, err := CalculateNextRelease(semver.Version{}, commits)
+
+	require.Nil(t, err)
+	assert.Equal(t, "1.0.0", release.Version.String())
+}

--- a/internal/semrel/commands.go
+++ b/internal/semrel/commands.go
@@ -64,7 +64,7 @@ the commit messages in the current (local) git repository.`,
 func calculateNextRelease(gitHubSlug string) (Release, error) {
 	tags, tagsErr := github.FetchTags(gitHubSlug)
 	if tagsErr != nil {
-		log.Fatal(tagsErr)
+		log.Fatal("Error while fetching tags", tagsErr)
 	}
 
 	var latestVersion semver.Version
@@ -76,7 +76,7 @@ func calculateNextRelease(gitHubSlug string) (Release, error) {
 		latestTag := tags[len(tags)-1]
 		version, parseVersionErr := semver.Parse(latestTag.TagName())
 		if parseVersionErr != nil {
-			log.Fatal(parseVersionErr)
+			log.Fatal("Error while parsing version.", parseVersionErr)
 		}
 
 		latestVersion = version
@@ -85,7 +85,7 @@ func calculateNextRelease(gitHubSlug string) (Release, error) {
 
 	commits, commitsErr := git.FetchCommits(".", latestVersionSha)
 	if commitsErr != nil {
-		log.Fatal(commitsErr)
+		log.Fatal("Error while fetching commits.", commitsErr)
 	}
 
 	return CalculateNextRelease(latestVersion, commits)

--- a/internal/semrel/release_test.go
+++ b/internal/semrel/release_test.go
@@ -1,7 +1,11 @@
 package semrel
 
 import (
+	"fmt"
+	"sort"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/VinnieApps/cicd-toolbox/internal/git"
 	"github.com/VinnieApps/cicd-toolbox/internal/semver"
@@ -9,78 +13,85 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCalculateNextReleaseReturnsSameIfNoCommits(t *testing.T) {
-	release, err := CalculateNextRelease(semver.Version{}, make([]git.Commit, 0))
+func TestChangeLog(t *testing.T) {
+	messagesByType := map[string][]string{
+		"feat":     []string{"this is a new feature", "another feature"},
+		"feature":  []string{"one more feature", "i love features"},
+		"chore":    []string{"cleaning up", "fix build"},
+		"refactor": []string{"moving some code around"},
+	}
 
-	require.Nil(t, err)
-	assert.Equal(t, "0.0.0", release.Version.String())
-}
-
-func TestCalculateNextReleaseAlwaysReturnNextPatch(t *testing.T) {
-	commits := []git.Commit{
-		git.Commit{
-			Message: "chore: this is a test",
-			SHA:     "1234abcd1234",
-		},
-		git.Commit{
-			Message: "Merge PR Bla Bla Bla",
-			SHA:     "1234abcd1234",
-		},
-		git.Commit{
-			Message: "refactor: move code from here to there",
-			SHA:     "1234abcd1234",
-		},
+	commits := make([]git.Commit, 0)
+	for commitType, messages := range messagesByType {
+		for _, message := range messages {
+			commits = append(commits, git.Commit{
+				Message: fmt.Sprintf("%s: %s", commitType, message),
+				SHA:     "1234abcd4321",
+			})
+		}
 	}
 	release, err := CalculateNextRelease(semver.Version{}, commits)
-
 	require.Nil(t, err)
-	assert.Equal(t, "0.0.1", release.Version.String())
+
+	expectedParts := []string{
+		"", "", "", "", "", "",
+		fmt.Sprintf("## 0.1.0 (%s)", time.Now().Format("2006-01-02")),
+		"#### Refactor", "* moving some code around (1234abcd)",
+		"#### Feature", "* this is a new feature (1234abcd)", "* another feature (1234abcd)", "* one more feature (1234abcd)", "* i love features (1234abcd)",
+		"#### Chore", "* cleaning up (1234abcd)", "* fix build (1234abcd)",
+	}
+	sort.Strings(expectedParts)
+
+	parts := strings.Split(release.ChangeLog(), "\n")
+	sort.Strings(parts)
+
+	assert.Equal(t, expectedParts, parts)
 }
 
-func TestCalculateNextReleaseReturnNextMinorIfNewFeature(t *testing.T) {
-	commits := []git.Commit{
-		git.Commit{
-			Message: "feature: this is a test",
-			SHA:     "1234abcd1234",
-		},
-		git.Commit{
-			Message: "Merge PR Bla Bla Bla",
-			SHA:     "1234abcd1234",
-		},
-		git.Commit{
-			Message: "feat: move code from here to there",
-			SHA:     "1234abcd1234",
-		},
+func TestChangesByType(t *testing.T) {
+	messagesByType := map[string][]string{
+		"feat":     []string{"this is a new feature", "another feature"},
+		"feature":  []string{"one more feature", "i love features"},
+		"chore":    []string{"cleaning up", "fix build"},
+		"refactor": []string{"moving some code around"},
+	}
+
+	commits := make([]git.Commit, 0)
+	for commitType, messages := range messagesByType {
+		for _, message := range messages {
+			commits = append(commits, git.Commit{
+				Message: fmt.Sprintf("%s: %s", commitType, message),
+				SHA:     "1234abcd4321",
+			})
+		}
 	}
 	release, err := CalculateNextRelease(semver.Version{}, commits)
-
 	require.Nil(t, err)
-	assert.Equal(t, "0.1.0", release.Version.String())
-}
 
-func TestCalculateNextReleaseReturnNextMajorWhenBreakingChange(t *testing.T) {
-	commits := []git.Commit{
-		git.Commit{
-			Message: `feat: this is a new feature
+	changesByType := release.ChangesByType()
+	assert.Equal(t, 3, len(changesByType))
 
-This is an important change.
-
-BREAKING CHANGE:
-Now the return value is going to be encrypted.
-`,
-			SHA: "1234abcd1234",
-		},
-		git.Commit{
-			Message: "Merge PR Bla Bla Bla",
-			SHA:     "1234abcd1234",
-		},
-		git.Commit{
-			Message: "feat: move code from here to there",
-			SHA:     "1234abcd1234",
-		},
+	expectedTypes := []string{"chore", "feature", "refactor"}
+	expectedMessagesByType := map[string][]string{
+		"chore":    messagesByType["chore"],
+		"feature":  append(messagesByType["feat"], messagesByType["feature"]...),
+		"refactor": messagesByType["refactor"],
 	}
-	release, err := CalculateNextRelease(semver.Version{}, commits)
 
-	require.Nil(t, err)
-	assert.Equal(t, "1.0.0", release.Version.String())
+	for _, expectedType := range expectedTypes {
+		changes, exists := changesByType[expectedType]
+		assert.True(t, exists, "Expected type to exist in result: %s", expectedType)
+
+		messages := make([]string, len(changes))
+		for i, change := range changes {
+			messages[i] = change.ParsedMessage.Subject
+		}
+
+		sort.Strings(messages)
+
+		expectedMessages := expectedMessagesByType[expectedType]
+		sort.Strings(expectedMessages)
+
+		assert.Equal(t, expectedMessages, messages)
+	}
 }


### PR DESCRIPTION
# What's in this PR?

Add a command to generate a change log in Markdown format using semantic release standards.

```
$ go run cmd/main.go semantic-release change-log --help
Prints the change log containing information about what changed since the previous release

Usage:
  cicd semantic-release change-log {GITHUB_SLUG} [flags]

Flags:
  -h, --help   help for change-log

Global Flags:
      --github-token string   GitHub API Token
```

# How did I test it?

- Added unit tests for change log calculation
- Ran the command from the command line
- Added the command to the PR GitHub Action