### PR TITLE
Add Create Release Command

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -1,7 +1,7 @@
 name: Release Build
 on:
   push:
-    branches-ignore:
+    branches:
       - master
 
 jobs:

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -1,0 +1,30 @@
+name: Release Build
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Build
+        run: go run cmd/main.go golang build --os darwin --os linux --os windows --arch amd64 cmd/main.go
+
+      - name: Test
+        run: go run cmd/main.go golang run-tests
+
+      - name: Release
+        run: go run cmd/main.go semantic-release publish-release vinnieapps/cicd-toolbox --github-token ${{ secrets.GITHUB_TOKEN }} --upload build/binaries

--- a/internal/github/commands.go
+++ b/internal/github/commands.go
@@ -22,9 +22,26 @@ func CreateGitHubCommand() *cobra.Command {
 
 	gitHubCommand.PersistentFlags().StringVarP(&GitHubToken, "github-token", "", "", "GitHub API Token")
 
+	gitHubCommand.AddCommand(createCreateReleaseCommand())
 	gitHubCommand.AddCommand(createListCommitsCommand())
 	gitHubCommand.AddCommand(createListTagsCommand())
 	return gitHubCommand
+}
+
+func createCreateReleaseCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "create-release {GITHUB_SLUG}",
+		Short: "Create a release in GitHub",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			user, userErr := GetAuthenticatedUser()
+			if userErr != nil {
+				log.Fatal(userErr)
+			}
+
+			fmt.Printf("Username: %s\n", user.Login)
+		},
+	}
 }
 
 func createListCommitsCommand() *cobra.Command {

--- a/internal/github/commands.go
+++ b/internal/github/commands.go
@@ -22,26 +22,9 @@ func CreateGitHubCommand() *cobra.Command {
 
 	gitHubCommand.PersistentFlags().StringVarP(&GitHubToken, "github-token", "", "", "GitHub API Token")
 
-	gitHubCommand.AddCommand(createCreateReleaseCommand())
 	gitHubCommand.AddCommand(createListCommitsCommand())
 	gitHubCommand.AddCommand(createListTagsCommand())
 	return gitHubCommand
-}
-
-func createCreateReleaseCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "create-release {GITHUB_SLUG}",
-		Short: "Create a release in GitHub",
-		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			user, userErr := GetAuthenticatedUser()
-			if userErr != nil {
-				log.Fatal(userErr)
-			}
-
-			fmt.Printf("Username: %s\n", user.Login)
-		},
-	}
 }
 
 func createListCommitsCommand() *cobra.Command {

--- a/internal/github/objects.go
+++ b/internal/github/objects.go
@@ -1,5 +1,12 @@
 package github
 
+// Types for GitHub objects
+const (
+	ObjectTypeBlob   = "blob"
+	ObjectTypeCommit = "commit"
+	ObjectTypeTree   = "tree"
+)
+
 // Object can represents different Git data objects, normally it is a commit
 type Object struct {
 	SHA  string `json:"sha"`

--- a/internal/github/references.go
+++ b/internal/github/references.go
@@ -1,6 +1,9 @@
 package github
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // ReferenceTagPrefix References that have this prefix are tags
 const ReferenceTagPrefix = "refs/tags/"
@@ -19,4 +22,26 @@ func (ref Reference) TagName() string {
 	}
 
 	return ""
+}
+
+type createReferenceBody struct {
+	Reference string `json:"ref"`
+	SHA       string `json:"sha"`
+}
+
+// CreateReference creates a reference in GitHub. Name should be of the format: refs/type/name
+// e.g.: refs/tag/v1.2.0
+func CreateReference(gitHubSlug, name, sha string) error {
+	ref := createReferenceBody{
+		Reference: name,
+		SHA:       sha,
+	}
+
+	createRefRequest, createRefErr := createGitHubPOSTRequest(fmt.Sprintf("/repos/%s/git/refs", gitHubSlug), ref)
+	if createRefErr != nil {
+		return createRefErr
+	}
+
+	_, err := executeRequest(createRefRequest)
+	return err
 }

--- a/internal/github/release.go
+++ b/internal/github/release.go
@@ -1,0 +1,21 @@
+package github
+
+// Tag represents a GitHub tag
+type Tag struct {
+	Message string `json:"message"`
+	Object  string `json:"object"`
+	Tag     string `json:"tag"`
+	Tagger  Tagger `json:"tagger"`
+	Type    string `json:"type"`
+}
+
+// Tagger represents the owner of a Release/Tag
+type Tagger struct {
+	Date  string `json:"date"`
+	Email string `json:"email"`
+	Name  string `json:"name"`
+}
+
+func CreateRelease(commit Commit) {
+
+}

--- a/internal/github/release.go
+++ b/internal/github/release.go
@@ -1,21 +1,24 @@
 package github
 
-// Tag represents a GitHub tag
-type Tag struct {
-	Message string `json:"message"`
-	Object  string `json:"object"`
-	Tag     string `json:"tag"`
-	Tagger  Tagger `json:"tagger"`
-	Type    string `json:"type"`
+import "fmt"
+
+// ReleaseBody represents the body of a create release request
+type ReleaseBody struct {
+	Body            string `json:"body"`
+	IsDraft         bool   `json:"draft"`
+	Name            string `json:"name"`
+	PreRelease      bool   `json:"prerelease"`
+	TagName         string `json:"tag_name"`
+	TargetCommitish string `json:"target_commitish"`
 }
 
-// Tagger represents the owner of a Release/Tag
-type Tagger struct {
-	Date  string `json:"date"`
-	Email string `json:"email"`
-	Name  string `json:"name"`
-}
+// CreateRelease creates a release for the repository as specified
+func CreateRelease(gitHubSlug string, releaseBody ReleaseBody) error {
+	postRequest, createRequestErr := createGitHubPOSTRequest(fmt.Sprintf("/repos/%s/releases", gitHubSlug), releaseBody)
+	if createRequestErr != nil {
+		return createRequestErr
+	}
 
-func CreateRelease(commit Commit) {
-
+	_, executeErr := executeRequest(postRequest)
+	return executeErr
 }

--- a/internal/github/release.go
+++ b/internal/github/release.go
@@ -1,9 +1,15 @@
 package github
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+)
 
-// ReleaseBody represents the body of a create release request
-type ReleaseBody struct {
+// ReleaseRequestBody represents the body of a create release request
+type ReleaseRequestBody struct {
 	Body            string `json:"body"`
 	IsDraft         bool   `json:"draft"`
 	Name            string `json:"name"`
@@ -12,13 +18,61 @@ type ReleaseBody struct {
 	TargetCommitish string `json:"target_commitish"`
 }
 
+type ReleaseResponseBody struct {
+	AssetsURL       string `json:"assets_url"`
+	ID              int64  `json:"id"`
+	Name            string `json:"name"`
+	TagName         string `json:"tag_name"`
+	TarballURL      string `json:"tarball_url"`
+	TargetCommitish string `json:"target_commitish"`
+	UploadURL       string `json:"upload_url"`
+	ZipballURL      string `json:"zipball_url"`
+}
+
 // CreateRelease creates a release for the repository as specified
-func CreateRelease(gitHubSlug string, releaseBody ReleaseBody) error {
+func CreateRelease(gitHubSlug string, releaseBody ReleaseRequestBody) (ReleaseResponseBody, error) {
+	var releaseResponse ReleaseResponseBody
+
 	postRequest, createRequestErr := createGitHubPOSTRequest(fmt.Sprintf("/repos/%s/releases", gitHubSlug), releaseBody)
 	if createRequestErr != nil {
-		return createRequestErr
+		return releaseResponse, createRequestErr
 	}
 
-	_, executeErr := executeRequest(postRequest)
-	return executeErr
+	responseBody, executeErr := executeRequest(postRequest)
+	if executeErr != nil {
+		return releaseResponse, executeErr
+	}
+
+	bodyData, readErr := ioutil.ReadAll(responseBody.Body)
+	if readErr != nil {
+		return releaseResponse, readErr
+	}
+
+	unmarshalErr := json.Unmarshal(bodyData, &releaseResponse)
+	return releaseResponse, unmarshalErr
+}
+
+// UploadAssetsToRelease uploads the specified assets to the release asset URL
+func UploadAssetsToRelease(uploadURL string, assetsToUpload []string) error {
+	indexOfBrackets := strings.LastIndex(uploadURL, "{")
+	uploadURL = uploadURL[:indexOfBrackets]
+
+	for _, asset := range assetsToUpload {
+		file, openErr := os.Open(asset)
+		if openErr != nil {
+			return openErr
+		}
+
+		uploadRequest, createRequestErr := createGitHubUploadRequest(uploadURL, file)
+		if createRequestErr != nil {
+			return createRequestErr
+		}
+
+		_, executeRequestErr := executeRequest(uploadRequest)
+		if executeRequestErr != nil {
+			return executeRequestErr
+		}
+	}
+
+	return nil
 }

--- a/internal/github/users.go
+++ b/internal/github/users.go
@@ -1,0 +1,9 @@
+package github
+
+// User represents a GitHub user
+type User struct {
+	Email string `json:"email"`
+	ID    int64  `json:"id"`
+	Login string `json:"login"`
+	Name  string `json:"name"`
+}

--- a/internal/golang/commands.go
+++ b/internal/golang/commands.go
@@ -88,7 +88,9 @@ func createRunTestsCommand() *cobra.Command {
 				log.Fatal(readErr)
 			}
 
-			RunTestsWithCoverage(packages)
+			if err := RunTestsWithCoverage(packages); err != nil {
+				log.Fatal(err)
+			}
 		},
 	}
 }

--- a/internal/golang/tests.go
+++ b/internal/golang/tests.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"go/build"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/VinnieApps/cicd-toolbox/internal/executil"
 )
 
 // RunTestsWithCoverage runs tests for all packages and generate coverage data.
@@ -28,13 +29,5 @@ func RunTestsWithCoverage(packages []*build.Package) error {
 	}
 
 	cmd := exec.Command("go", "test", "-cover", "-coverprofile=build/coverage/all.out", "./...")
-	runErr := cmd.Run()
-	if runErr != nil {
-		log.Printf("-- Tests failed --")
-		output, _ := cmd.CombinedOutput()
-		log.Println(string(output))
-		log.Fatal(runErr)
-	}
-
-	return nil
+	return executil.RunAndCaptureOutputIfError(cmd)
 }

--- a/internal/semrel/commands.go
+++ b/internal/semrel/commands.go
@@ -73,7 +73,7 @@ func createPublishReleaseCommand() *cobra.Command {
 			log.Printf("Creating reference %s to commit -> %s (%s)\n", reference, latestCommit.Message, latestCommit.ShortSHA())
 
 			if refErr := github.CreateReference(gitHubSlug, reference, latestCommit.SHA); refErr != nil {
-				log.Fatal("Error while creating reference\n%v", refErr)
+				log.Fatalf("Error while creating reference: %v", refErr.Error())
 			}
 		},
 	}

--- a/internal/semrel/commands.go
+++ b/internal/semrel/commands.go
@@ -22,6 +22,7 @@ func CreateSemanticReleaseCommand() *cobra.Command {
 	semanticReleaseCommand.PersistentFlags().StringVarP(&github.GitHubToken, "github-token", "", "", "GitHub API Token")
 
 	semanticReleaseCommand.AddCommand(createChangeLogCommand())
+	semanticReleaseCommand.AddCommand(createPublishReleaseCommand())
 	semanticReleaseCommand.AddCommand(createVersionFileCommand())
 	return semanticReleaseCommand
 }
@@ -38,6 +39,32 @@ func createChangeLogCommand() *cobra.Command {
 			}
 
 			fmt.Println(nextRelease.ChangeLog())
+		},
+	}
+}
+
+func createPublishReleaseCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "publish-release {GITHUB_SLUG}",
+		Short: "Calculates the next version and publish the release to GitHub",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if github.GitHubToken == "" {
+				log.Fatal("GitHub token is required to publish a release.")
+			}
+
+			user, userErr := github.GetAuthenticatedUser()
+			if userErr != nil {
+				log.Fatal(userErr)
+			}
+			fmt.Printf("Logged in user is: %s\n", user.Login)
+
+			nextRelease, nextReleaseErr := calculateNextRelease(args[0])
+			if nextReleaseErr != nil {
+				log.Fatal(nextReleaseErr)
+			}
+
+			fmt.Printf("New version is %s\n", nextRelease.Version.String())
 		},
 	}
 }

--- a/internal/semrel/commands.go
+++ b/internal/semrel/commands.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/VinnieApps/cicd-toolbox/internal/git"
 	"github.com/VinnieApps/cicd-toolbox/internal/github"
@@ -45,16 +46,26 @@ func createChangeLogCommand() *cobra.Command {
 }
 
 func createPublishReleaseCommand() *cobra.Command {
-	return &cobra.Command{
+	var assetsToUpload []string
+	publishReleaseCommand := &cobra.Command{
 		Use:   "publish-release {GITHUB_SLUG}",
 		Short: "Calculates the next version and publish the release to GitHub",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			gitHubSlug := args[0]
+
 			if github.GitHubToken == "" {
 				log.Fatal("GitHub token is required to publish a release.")
 			}
 
-			gitHubSlug := args[0]
+			if len(assetsToUpload) == 0 {
+				log.Fatal("No assets to upload.")
+			}
+
+			filesToUpload, parseAssetErr := parseAssetPaths(assetsToUpload)
+			if parseAssetErr != nil {
+				log.Fatalf("Error while parsing assets to upload: %v", parseAssetErr)
+			}
 
 			nextRelease, nextReleaseErr := calculateNextRelease(args[0])
 			if nextReleaseErr != nil {
@@ -78,7 +89,7 @@ func createPublishReleaseCommand() *cobra.Command {
 			}
 
 			log.Println("Creating release...")
-			relErr := github.CreateRelease(gitHubSlug, github.ReleaseBody{
+			releaseResponse, relErr := github.CreateRelease(gitHubSlug, github.ReleaseRequestBody{
 				Body:            nextRelease.ChangeLog(),
 				IsDraft:         false,
 				Name:            tagName,
@@ -90,8 +101,22 @@ func createPublishReleaseCommand() *cobra.Command {
 			if relErr != nil {
 				log.Fatalf("Error while creating release: %v", relErr)
 			}
+
+			log.Print("Uploading files to release:")
+			for _, file := range filesToUpload {
+				log.Printf("  %s\n", file)
+			}
+
+			uploadErr := github.UploadAssetsToRelease(releaseResponse.UploadURL, filesToUpload)
+			if uploadErr != nil {
+				log.Fatalf("Error while uploading asset to release: %v", uploadErr)
+			}
 		},
 	}
+
+	publishReleaseCommand.Flags().StringArrayVarP(&assetsToUpload, "upload", "", []string{}, "Assets to upload. File or directory. If directory, all files in the directory will be uploaded individually (non-recursively).")
+
+	return publishReleaseCommand
 }
 
 func createVersionFileCommand() *cobra.Command {
@@ -141,4 +166,37 @@ func calculateNextRelease(gitHubSlug string) (Release, error) {
 	}
 
 	return CalculateNextRelease(latestVersion, commits)
+}
+
+func parseAssetPaths(assetsToUpload []string) ([]string, error) {
+	filesToUpload := make([]string, 0)
+	for _, asset := range assetsToUpload {
+		stat, statErr := os.Stat(asset)
+		if statErr != nil {
+			return nil, statErr
+		}
+
+		if stat.IsDir() {
+			entries, listErr := ioutil.ReadDir(asset)
+			if listErr != nil {
+				return nil, listErr
+			}
+
+			for _, dirEntry := range entries {
+				entryPath := filepath.Join(asset, dirEntry.Name())
+				entryStat, entryStatErr := os.Stat(entryPath)
+				if entryStatErr != nil {
+					return nil, entryStatErr
+				}
+				if entryStat.IsDir() {
+					continue
+				}
+				filesToUpload = append(filesToUpload, entryPath)
+			}
+		} else {
+			filesToUpload = append(filesToUpload, asset)
+		}
+	}
+
+	return filesToUpload, nil
 }


### PR DESCRIPTION
# What's in this PR?

- [x] Add Create Release command
- [x] Calculate new version number
- [x] Generate Changelog
- [x] Create Tag
- [x] Create Release
- [x] Upload artifacts to release

# How did I test it?

- Unit tests
- Execute from command line

# Example help

```
$ go run cmd/main.go semantic-release publish-release --help
Calculates the next version and publish the release to GitHub

Usage:
  cicd semantic-release publish-release {GITHUB_SLUG} [flags]

Flags:
  -h, --help                 help for publish-release
      --upload stringArray   Assets to upload. File or directory. If directory, all files in the directory will be uploaded individually (non-recursively).

Global Flags:
      --github-token string   GitHub API Token
```