### PR TITLE
chore: move to go 1.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go 1.14
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.14
 
       - name: Check out code
         uses: actions/checkout@v2


### PR DESCRIPTION
# What's in this PR?

Move GitHub action to use Go 1.14.

# How did I test it?

Built locally.