### PR TITLE
Improve golang build command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Change Log
         run: go run cmd/main.go semantic-release change-log vinnieapps/cicd-toolbox
 
+      - name: Package
+        run: go run cmd/main.go package -n cicd -f LICENSE -f README.md build/binaries/
+
       - name: Release
         if: github.ref == 'refs/heads/master'
-        run: go run cmd/main.go semantic-release publish-release vinnieapps/cicd-toolbox --github-token ${{ secrets.GITHUB_TOKEN }} --upload build/binaries
+        run: go run cmd/main.go semantic-release publish-release vinnieapps/cicd-toolbox --github-token ${{ secrets.GITHUB_TOKEN }} --upload build/packages

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build/
+/build/
 .DS_Store
 .version
 .vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Vinicius Isola
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/VinnieApps/cicd-toolbox/internal/build"
 	"github.com/VinnieApps/cicd-toolbox/internal/golang"
 	"github.com/VinnieApps/cicd-toolbox/internal/semrel"
 	"github.com/VinnieApps/cicd-toolbox/internal/semver"
@@ -18,6 +19,7 @@ func main() {
 		Long:  "An unopinionated toolbox for all Continuous Integration and Delivery needs.",
 	}
 
+	rootCommand.AddCommand(build.CreateCommands()...)
 	rootCommand.AddCommand(golang.CreateGoCommand())
 	rootCommand.AddCommand(semrel.CreateSemanticReleaseCommand())
 	rootCommand.AddCommand(semver.CreateSemVerCommand())

--- a/internal/build/commands.go
+++ b/internal/build/commands.go
@@ -1,0 +1,76 @@
+package build
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+// CreateCommands creates the root Build command
+func CreateCommands() []*cobra.Command {
+	return []*cobra.Command{
+		createPackageCommand(),
+	}
+}
+
+func createPackageCommand() *cobra.Command {
+	var additionalFiles []string
+	var baseName string
+
+	packageCommand := &cobra.Command{
+		Use:   "package {dirs-children}",
+		Short: "Create ZIP package containing multiple files",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 1 {
+				fmt.Println("One argument is required")
+				cmd.Help()
+				os.Exit(-1)
+			}
+
+			rootDir := args[0]
+			dirs, listErr := getChildrenDirectories(rootDir)
+			if listErr != nil {
+				panic(listErr)
+			}
+
+			outputDir := "build/packages"
+			if err := os.MkdirAll(outputDir, 0744); err != nil {
+				panic(err)
+			}
+
+			for _, dir := range dirs {
+				outputFile := filepath.Join(outputDir, fmt.Sprintf("%s_%s.zip", baseName, dir.Name()))
+				fmt.Printf("Creating package %s\n", outputFile)
+				CreatePackage(outputFile, filepath.Join(rootDir, dir.Name()), additionalFiles...)
+			}
+		},
+	}
+
+	currentDir, cdErr := os.Getwd()
+	if cdErr != nil {
+		panic(cdErr)
+	}
+
+	packageCommand.Flags().StringVarP(&baseName, "base-name", "n", filepath.Base(currentDir), "Base name for the packages. Default to working dir name.")
+	packageCommand.Flags().StringArrayVarP(&additionalFiles, "add-file", "f", []string{}, "A file to add to all packages created")
+
+	return packageCommand
+}
+
+func getChildrenDirectories(dir string) ([]os.FileInfo, error) {
+	childrenDir := make([]os.FileInfo, 0)
+	children, listErr := ioutil.ReadDir(dir)
+	if listErr != nil {
+		return nil, listErr
+	}
+	for _, child := range children {
+		if !child.IsDir() {
+			continue
+		}
+		childrenDir = append(childrenDir, child)
+	}
+	return childrenDir, nil
+}

--- a/internal/build/package.go
+++ b/internal/build/package.go
@@ -1,0 +1,78 @@
+package build
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+//CreatePackage create a zip package adding all content from a directory and also some aditional files.
+func CreatePackage(outputFile string, contentDirectory string, additionalFiles ...string) error {
+	zipFile, createErr := os.Create(outputFile)
+	if createErr != nil {
+		return createErr
+	}
+	defer zipFile.Close()
+
+	zipWriter := zip.NewWriter(zipFile)
+	defer zipWriter.Close()
+
+	addDirToZip(zipWriter, contentDirectory)
+	for _, fileToAdd := range additionalFiles {
+		addFileToZip(zipWriter, fileToAdd)
+	}
+
+	return nil
+}
+
+func addFileToZip(zipWriter *zip.Writer, pathToFile string) error {
+	fileStat, statErr := os.Stat(pathToFile)
+	if statErr != nil {
+		return statErr
+	}
+
+	return addFileToZipWithStat(zipWriter, pathToFile, fileStat)
+}
+
+func addFileToZipWithStat(zipWriter *zip.Writer, pathToFile string, fileStat os.FileInfo) error {
+	fileToAdd, openErr := os.Open(pathToFile)
+	if openErr != nil {
+		return openErr
+	}
+	defer fileToAdd.Close()
+
+	zipHeader, headerErr := zip.FileInfoHeader(fileStat)
+	if headerErr != nil {
+		return headerErr
+	}
+
+	zipHeader.Method = zip.Deflate
+
+	fileWriter, createErr := zipWriter.CreateHeader(zipHeader)
+	if createErr != nil {
+		return createErr
+	}
+
+	_, writeErr := io.Copy(fileWriter, fileToAdd)
+	return writeErr
+}
+
+func addDirToZip(zipWriter *zip.Writer, pathToDir string) error {
+	return filepath.Walk(pathToDir, func(childPath string, fileInfo os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if childPath == pathToDir {
+			return nil
+		}
+
+		if fileInfo.IsDir() {
+			// recurse
+			return nil
+		}
+
+		return addFileToZipWithStat(zipWriter, childPath, fileInfo)
+	})
+}

--- a/internal/golang/build.go
+++ b/internal/golang/build.go
@@ -51,14 +51,13 @@ func (buildSpec *BuildSpecification) Build() []error {
 }
 
 func compileForPlatform(buildSpec BuildSpecification, platform Platform) error {
-	os.MkdirAll(binariesDir, 0744)
+	outputDir := filepath.Join(binariesDir, fmt.Sprintf("%s_%s", platform.OperatingSystem, platform.Architecture))
+	os.MkdirAll(outputDir, 0744)
 
 	outFileName := "main"
 	if buildSpec.BaseName != "" {
 		outFileName = buildSpec.BaseName
 	}
-
-	outFileName = fmt.Sprintf("%s_%s_%s", outFileName, platform.Architecture, platform.OperatingSystem)
 
 	if platform.Extension != "" {
 		outFileName = fmt.Sprintf("%s.%s", outFileName, platform.Extension)
@@ -70,7 +69,7 @@ func compileForPlatform(buildSpec BuildSpecification, platform Platform) error {
 		commandArgs = append(commandArgs, "-ldflags", linkerArg)
 	}
 
-	commandArgs = append(commandArgs, "-o", filepath.Join(binariesDir, outFileName))
+	commandArgs = append(commandArgs, "-o", filepath.Join(outputDir, outFileName))
 	commandArgs = append(commandArgs, buildSpec.FileToBuild)
 
 	command := exec.Command("go", commandArgs...)

--- a/internal/golang/commands.go
+++ b/internal/golang/commands.go
@@ -32,11 +32,6 @@ func createBuildCommand() *cobra.Command {
 			platforms := Platforms.WithArchitectures(architectures...).
 				WithOperatingSystems(operatingSystems...)
 
-			fmt.Println("Compiling binary for following platforms:")
-			for _, platform := range platforms {
-				fmt.Printf(" - '%s' '%s'\n", platform.Architecture, platform.OperatingSystem)
-			}
-
 			buildSpec := BuildSpecification{
 				BaseName:        baseName,
 				FileToBuild:     args[0],


### PR DESCRIPTION
# What's in this PR?

Fixes #15.
- Changes the `golang build` command to output all binaries of same arch/os combination in the same folder
- Adds a package command that can create zip files from children directory in a directory
- Update GitHub workflow to package and release the package instead

# How did I test it?

Manually building and generating packages from the command line.